### PR TITLE
修改 Thread.isMainThread 

### DIFF
--- a/Practical Dependency Inversion.xcodeproj/project.pbxproj
+++ b/Practical Dependency Inversion.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		7E51258024B159EE002840CE /* PrimaryWithFallbackLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51257F24B159EE002840CE /* PrimaryWithFallbackLoader.swift */; };
 		7E51258224B15CCC002840CE /* ItemsUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E51258124B15CCC002840CE /* ItemsUIComposer.swift */; };
 		7EDDA12724B16093003393C1 /* ItemsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDDA12624B16093003393C1 /* ItemsViewControllerTests.swift */; };
+		A7F406A624BDB931005E381D /* MainThreadDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F406A524BDB931005E381D /* MainThreadDecoratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,7 @@
 		7EDDA11C24B15FF8003393C1 /* Practical Dependency InversionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Practical Dependency InversionTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7EDDA12024B15FF8003393C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7EDDA12624B16093003393C1 /* ItemsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsViewControllerTests.swift; sourceTree = "<group>"; };
+		A7F406A524BDB931005E381D /* MainThreadDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadDecoratorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +121,7 @@
 			children = (
 				7EDDA12024B15FF8003393C1 /* Info.plist */,
 				7EDDA12624B16093003393C1 /* ItemsViewControllerTests.swift */,
+				A7F406A524BDB931005E381D /* MainThreadDecoratorTests.swift */,
 			);
 			path = "Practical Dependency InversionTests";
 			sourceTree = "<group>";
@@ -243,6 +246,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A7F406A624BDB931005E381D /* MainThreadDecoratorTests.swift in Sources */,
 				7EDDA12724B16093003393C1 /* ItemsViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Practical Dependency Inversion/ItemsUIComposer.swift
+++ b/Practical Dependency Inversion/ItemsUIComposer.swift
@@ -35,12 +35,14 @@ class MainThreadDecorator: ItemsViewControllerSpec {
     }
     
     func items(completion: @escaping (Result<[Item], Error>) -> Void) {
-        print("it is on the same queue of caller")
-        guard (DispatchQueue.getSpecific(key: Self.mainQueueKey) == Self.mainQueueValue)
-        else {
-            DispatchQueue.main.async(execute: { self.loader.items(completion: completion)} )
-            return
+        loader.items {
+            result in
+            DispatchQueue.main.async {
+                completion(result)
+            }
+            
         }
-        loader.items(completion: completion)
     }
 }
+
+

--- a/Practical Dependency Inversion/ItemsUIComposer.swift
+++ b/Practical Dependency Inversion/ItemsUIComposer.swift
@@ -18,16 +18,24 @@ class ItemsUIComposer {
     }
 }
 
-private class MainThreadDecorator: ItemsViewControllerSpec {
+class MainThreadDecorator: ItemsViewControllerSpec {
     
     private let loader: ItemsViewControllerSpec
+    private static var didSetSpecific = false
+    private static let mainQueueKey = DispatchSpecificKey<Int>()
+    private static let mainQueueValue = 1
     
     init(loader: ItemsViewControllerSpec) {
         self.loader = loader
+        if Self.didSetSpecific {
+            return
+        }
+        DispatchQueue.main.setSpecific(key: Self.mainQueueKey, value: 1)
+        Self.didSetSpecific = true
     }
     
     func items(completion: @escaping (Result<[Item], Error>) -> Void) {
-        guard Thread.isMainThread else {
+        guard (DispatchQueue.getSpecific(key: Self.mainQueueKey) == Self.mainQueueValue) else {
             DispatchQueue.main.async(execute: { self.loader.items(completion: completion)} )
             return
         }

--- a/Practical Dependency Inversion/ItemsUIComposer.swift
+++ b/Practical Dependency Inversion/ItemsUIComposer.swift
@@ -21,17 +21,9 @@ class ItemsUIComposer {
 class MainThreadDecorator: ItemsViewControllerSpec {
     
     private let loader: ItemsViewControllerSpec
-    private static var didSetSpecific = false
-    private static let mainQueueKey = DispatchSpecificKey<Int>()
-    private static let mainQueueValue = 1
     
     init(loader: ItemsViewControllerSpec) {
         self.loader = loader
-        if Self.didSetSpecific {
-            return
-        }
-        DispatchQueue.main.setSpecific(key: Self.mainQueueKey, value: 1)
-        Self.didSetSpecific = true
     }
     
     func items(completion: @escaping (Result<[Item], Error>) -> Void) {

--- a/Practical Dependency Inversion/ItemsUIComposer.swift
+++ b/Practical Dependency Inversion/ItemsUIComposer.swift
@@ -35,7 +35,9 @@ class MainThreadDecorator: ItemsViewControllerSpec {
     }
     
     func items(completion: @escaping (Result<[Item], Error>) -> Void) {
-        guard (DispatchQueue.getSpecific(key: Self.mainQueueKey) == Self.mainQueueValue) else {
+        print("it is on the same queue of caller")
+        guard (DispatchQueue.getSpecific(key: Self.mainQueueKey) == Self.mainQueueValue)
+        else {
             DispatchQueue.main.async(execute: { self.loader.items(completion: completion)} )
             return
         }

--- a/Practical Dependency InversionTests/MainThreadDecoratorTests.swift
+++ b/Practical Dependency InversionTests/MainThreadDecoratorTests.swift
@@ -13,47 +13,84 @@ class MainThreadDecoratorTests: XCTestCase {
     
     
     func testCanCheckNotOnMainQueue() throws {
-        let testQueue = DispatchQueue(label: #function)
+        let testQueue = OperationQueue()
         let await = XCTestExpectation(description: #function)
-        var result:Bool?
-        testQueue.async {
-            checkQueue(queue: .main, result: &result)
+        let operation = BlockOperation {
+            XCTAssertEqual(testQueue, OperationQueue.current)
+            XCTAssertNil(OperationQueue.current?.underlyingQueue)
             await.fulfill()
         }
+        testQueue.addOperation(operation)
         wait(for: [await], timeout: 1)
-        let returned = try XCTUnwrap(result)
-        XCTAssertFalse(returned)
     }
     func testCanCheckIsOnMainQueue() throws {
-        let testQueue = DispatchQueue(label: #function)
+        let testQueue = OperationQueue()
         let await = XCTestExpectation(description: #function)
-        var result:Bool?
-        testQueue.async {
+        
+        let operation = BlockOperation {
+            XCTAssertEqual(testQueue, OperationQueue.current)
+            XCTAssertNil(OperationQueue.current?.underlyingQueue)
             DispatchQueue.main.async {
-                checkQueue(queue: .main, result: &result)
+                XCTAssertEqual(.main, OperationQueue.current)
+                XCTAssertEqual(DispatchQueue.main, OperationQueue.current?.underlyingQueue)
                 await.fulfill()
             }
         }
+        testQueue.addOperation(operation)
         wait(for: [await], timeout: 1)
-        let returned = try XCTUnwrap(result)
-        XCTAssertTrue(returned)
     }
+    
+    class ItemViewControllerSpecCustomQueue: ItemsViewControllerSpec {
+        internal init(_ contiueQueue: DispatchQueue) {
+            self.contiueQueue = contiueQueue
+        }
+        
+        static let queueName = "Custom Queue"
+        lazy var queue = DispatchQueue(label: Self.queueName)
+        var contiueQueue: DispatchQueue
+        private(set) var isFetched: Bool = false
+        
+        func items(completion: @escaping (Result<[Item], Error>) -> Void) {
+            queue.async {
+            print(2)
+                self.isFetched = true
+                self.contiueQueue.async {
+                    completion(.success([]))
+                }
+            }
+        }
+    }
+    
     func testItemUIComposerIsOnMainQueue() throws {
         let await = XCTestExpectation(description: #function)
-        let spec = ItemViewControllerSpecSpy()
+        let spec = ItemViewControllerSpecCustomQueue(.main)
         let sut = MainThreadDecorator(loader: spec)
-        var result:Bool? = nil
         sut.items {  (_) in
-            checkQueue(queue: .main, result: &result)
+            let clabel = __dispatch_queue_get_label(nil)
+            let currectLabel = String(cString: clabel)
+            XCTAssertEqual(
+                currectLabel,
+                DispatchQueue.main.label)
+            
             await.fulfill()
         }
         wait(for: [await], timeout: 1)
-        let returned = try XCTUnwrap(result)
-        XCTAssertTrue(returned)
     }
-}
-
-
-func checkQueue(queue: DispatchQueue, result: inout Bool?){
-    result = queue == OperationQueue.current?.underlyingQueue
+    
+    func testItemUIComposerIsNotMainQueue() throws {
+        let queue = DispatchQueue(label: #function)
+        let await = XCTestExpectation(description: #function)
+        let spec = ItemViewControllerSpecCustomQueue(queue)
+        let sut = MainThreadDecorator(loader: spec)
+        sut.items {  (_) in
+            let clabel = __dispatch_queue_get_label(nil)
+            let currectLabel = String(cString: clabel)
+            XCTAssertNotEqual(
+                currectLabel,
+                DispatchQueue.main.label)
+            
+            await.fulfill()
+        }
+        wait(for: [await], timeout: 1)
+    }
 }

--- a/Practical Dependency InversionTests/MainThreadDecoratorTests.swift
+++ b/Practical Dependency InversionTests/MainThreadDecoratorTests.swift
@@ -1,0 +1,59 @@
+//
+//  MainThreadTests.swift
+//  Practical Dependency InversionTests
+//
+//  Created by 游宗諭 on 2020/7/14.
+//  Copyright © 2020 Hanyu. All rights reserved.
+//
+
+import XCTest
+@testable import Practical_Dependency_Inversion
+
+class MainThreadDecoratorTests: XCTestCase {
+    
+    
+    func testCanCheckNotOnMainQueue() throws {
+        let testQueue = DispatchQueue(label: #function)
+        let await = XCTestExpectation(description: #function)
+        var result:Bool?
+        testQueue.async {
+            checkQueue(queue: .main, result: &result)
+            await.fulfill()
+        }
+        wait(for: [await], timeout: 1)
+        let returned = try XCTUnwrap(result)
+        XCTAssertFalse(returned)
+    }
+    func testCanCheckIsOnMainQueue() throws {
+        let testQueue = DispatchQueue(label: #function)
+        let await = XCTestExpectation(description: #function)
+        var result:Bool?
+        testQueue.async {
+            DispatchQueue.main.async {
+                checkQueue(queue: .main, result: &result)
+                await.fulfill()
+            }
+        }
+        wait(for: [await], timeout: 1)
+        let returned = try XCTUnwrap(result)
+        XCTAssertTrue(returned)
+    }
+    func testItemUIComposerIsOnMainQueue() throws {
+        let await = XCTestExpectation(description: #function)
+        let spec = ItemViewControllerSpecSpy()
+        let sut = MainThreadDecorator(loader: spec)
+        var result:Bool? = nil
+        sut.items {  (_) in
+            checkQueue(queue: .main, result: &result)
+            await.fulfill()
+        }
+        wait(for: [await], timeout: 1)
+        let returned = try XCTUnwrap(result)
+        XCTAssertTrue(returned)
+    }
+}
+
+
+func checkQueue(queue: DispatchQueue, result: inout Bool?){
+    result = queue == OperationQueue.current?.underlyingQueue
+}


### PR DESCRIPTION
根據 這篇文章: [GCD's Main Queue vs. Main Thread](http://blog.benjamin-encz.de/post/main-queue-vs-main-thread/?fbclid=IwAR2W9FHQUIntKF2WwwBWR4yet4k3StuBO8E-SqSTtIQ7fJYlgyXQ9rJgXoE)

我研究了一下這麼在 Swift 5 實作他。

更新，我後來改用 label 來作為 Equable 的處理，透過 Objective-C的 `__dispatch_queue_get_label` 拿到 Current Queue 的 label。